### PR TITLE
Remove `six` from production code

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,14 +3,14 @@ Maintainer: Trevor Woerner <twoerner@gmail.com>
 Section: utils
 Priority: optional
 Build-Depends: debhelper (>= 9),
-               python-all (>= 2.7),
-               python-setuptools,
+               python3 (>= 3.8),
+               python3-setuptools,
 Standards-Version: 3.8.4
-XS-Python-Version: >= 2.7
+XS-Python-Version: >= 3.8
 
 Package: bmaptool
 Architecture: all
-Depends: python (>=2.7),
+Depends: python (>=3.8),
 	 python-gpgme,
          ${misc:Depends},
          ${python:Depends},

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,4 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with=python2
+	dh $@ --with=python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "bmaptool"
 description = "BMAP tools"
 dynamic = ["version"]
 dependencies = [
-    "six >= 1.16.0",
     "gpg >= 1.10.0",
 ]
 required-python = ">= 3.8"
@@ -31,6 +30,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "black >= 22.3.0",
+    "six >= 1.16.0",
 ]
 
 [project.urls]

--- a/src/bmaptool/BmapCopy.py
+++ b/src/bmaptool/BmapCopy.py
@@ -63,9 +63,8 @@ import sys
 import hashlib
 import logging
 import datetime
-from six import reraise
-from six.moves import queue as Queue
-from six.moves import _thread as thread
+import queue
+import _thread as thread
 from typing import Optional
 from xml.etree import ElementTree
 from .BmapHelpers import human_size
@@ -684,7 +683,7 @@ class BmapCopy(object):
 
         # Create the queue for block batches and start the reader thread, which
         # will read the image in batches and put the results to '_batch_queue'.
-        self._batch_queue = Queue.Queue(self._batch_queue_len)
+        self._batch_queue = queue.Queue(self._batch_queue_len)
         thread.start_new_thread(self._get_data, (verify,))
 
         blocks_written = 0
@@ -714,7 +713,7 @@ class BmapCopy(object):
                 # The reader thread encountered an error and passed us the
                 # exception.
                 exc_info = batch[1]
-                reraise(exc_info[0], exc_info[1], exc_info[2])
+                raise exc_info[1]
 
             (start, end, buf) = batch[1:4]
 

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -34,7 +34,7 @@ import sys
 import tempfile
 import filecmp
 import subprocess
-from six.moves import zip_longest
+from itertools import zip_longest
 from tests import helpers
 from bmaptool import BmapHelpers, BmapCreate, Filemap
 

--- a/tests/test_filemap.py
+++ b/tests/test_filemap.py
@@ -29,7 +29,7 @@ import sys
 import random
 import itertools
 import tests.helpers
-from six.moves import zip_longest
+from itertools import zip_longest
 from bmaptool import Filemap
 
 # This is a work-around for Centos 6


### PR DESCRIPTION
Removes the `six` module from released production code. The old code in the test cases used for testing compatability still uses `six`, so it is kept as a dev dependency.