### PR TITLE
Add --removable-device option

### DIFF
--- a/docs/man1/bmaptool.1
+++ b/docs/man1/bmaptool.1
@@ -199,7 +199,6 @@ Disable automatic bmap file discovery and force flashing entire IMAGE without bm
 .RS 2
 Do not verify the OpenPGP bmap file signature (not recommended).
 .RE
-.RE
 
 .PP
 \-\-no-verify
@@ -215,6 +214,8 @@ IMAGE matches the checksums.
 Write periodic machine-readable progress reports to a fifo in the format
 used by \fBpsplash\fR. Each progress report consists of "PROGRESS" followed
 by a space, an integer percentage and a newline.
+.RE
+
 .RE
 .RE
 

--- a/docs/man1/bmaptool.1
+++ b/docs/man1/bmaptool.1
@@ -216,6 +216,15 @@ used by \fBpsplash\fR. Each progress report consists of "PROGRESS" followed
 by a space, an integer percentage and a newline.
 .RE
 
+.PP
+\-\-removable\-device
+.RS 2
+Copy to destination only if it is a removable block device. This option is
+recommended when writing on SD Card or USB key to avoid involuntary
+destructive operations on non-removable disks. The copy command fails when the
+destination file does not exist, is not a block device or is not removable.
+.RE
+
 .RE
 .RE
 


### PR DESCRIPTION
Copy to destination only if it is a removable block device. This option is
recommended when writing on SD Card or USB key to avoid involuntary
destructive operations on non-removable disks. The copy command fails when the
destination file does not exist, is not a block device or is not removable.