### PR TITLE
pyproject.toml: six is a required dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           python -m build
       - name: Install package
         run: |
-          pip install -e .[dev]
+          pip install -e .
       - name: Run tests
         run: |
           python -m unittest -vb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ description = "BMAP tools"
 dynamic = ["version"]
 dependencies = [
     "gpg >= 1.10.0",
+    "six >= 1.16.0",
 ]
 required-python = ">= 3.8"
 authors = [
@@ -30,7 +31,6 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "black >= 22.3.0",
-    "six >= 1.16.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
When not installed, a clean/fresh install results in:

	$ bmaptool --version
	Traceback (most recent call last):
	  File "/2opt/devel/bmaptool/venv.python3.11/bin/bmaptool", line 5, in <module>
	    from bmaptool.CLI import main
	  File "/2opt/devel/bmaptool/venv.python3.11/lib64/python3.11/site-packages/bmaptool/CLI.py", line 42, in <module>
	    from . import BmapCreate, BmapCopy, BmapHelpers, TransRead
	  File "/2opt/devel/bmaptool/venv.python3.11/lib64/python3.11/site-packages/bmaptool/TransRead.py", line 36, in <module>
	    from six.moves.urllib import parse as urlparse
	ModuleNotFoundError: No module named 'six'