### PR TITLE
Add option to copy to an Android Sparse Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ python3 -m venv .venv
 Next install the project in editable mode with development dependencies:
 
 ```bash
-pip install -m .[dev]
+pip install -e .[dev]
 ```
 
 Finally, to run tests use `unittest`:

--- a/src/bmaptool/CLI.py
+++ b/src/bmaptool/CLI.py
@@ -526,7 +526,12 @@ def copy_command(args):
             writer = BmapCopy.BmapBdevCopy(image_obj, dest_obj, bmap_obj, image_size)
         else:
             dest_str = "file '%s'" % os.path.basename(args.dest)
-            writer = BmapCopy.BmapCopy(image_obj, dest_obj, bmap_obj, image_size)
+            if args.format == "simg":
+                writer = BmapCopy.BmapAndroidSparseImageCopy(image_obj, dest_obj, bmap_obj, image_size)
+            elif args.format == "raw":
+                writer = BmapCopy.BmapCopy(image_obj, dest_obj, bmap_obj, image_size)
+            else:
+                error_out(f"Unsupported destination format: {args.format}")
     except BmapCopy.Error as err:
         error_out(err)
 
@@ -714,6 +719,10 @@ def parse_arguments():
     # The --bmap option
     text = "the block map file for the image"
     parser_copy.add_argument("--bmap", help=text)
+    parser_copy.add_argument("--format",
+                             help="format of the destination file",
+                             choices=['raw', 'simg'],
+                             default="raw")
 
     # The --nobmap option
     text = "allow copying without a bmap file"


### PR DESCRIPTION
This adds a option to do `bmaptool copy --format simg ...` to convert to an Android Sparse Image format file.

Android Sparse Image files fulfill essentially the same purpose as .bmap files, but they are simpler and therefore supported in low level software like the U-boot `mmc swrite ...` command). Background info on the format: https://2net.co.uk/tutorial/android-sparse-image-format

Is this a feature the bmaptool project is willing to accept? If so I can cleanup, document, unit test, etc

