### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,11 @@ python3 -m venv .venv
 Next install the project in editable mode with development dependencies:
 
 ```bash
-pip install -m .[dev]
+pip install .[dev]
 ```
+
+Note: You may need to install the development package for `libgpgme` on your
+      system. Depending on your OS this may be called `libgpgme-dev`.
 
 Finally, to run tests use `unittest`:
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ python3 -m venv .venv
 Next install the project in editable mode with development dependencies:
 
 ```bash
-pip install .[dev]
+pip install -m .[dev]
 ```
 
 Note: You may need to install the development package for `libgpgme` on your


### PR DESCRIPTION
On some systems `libgpgme` might be installed, but `libgpgme-dev` is not. Provide a hint to the user what might be the reason if the install fails.