### PR TITLE
README: Fix pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ python3 -m venv .venv
 Next install the project in editable mode with development dependencies:
 
 ```bash
-pip install -m .[dev]
+pip install -e '.[dev]'
 ```
 
 Finally, to run tests use `unittest`:


### PR DESCRIPTION
The pip install command accidentally had `-m` when `-e` was intended. Also quote the argument for maximum shell compatibility