### PR TITLE
Add --keyring and --fingerprint options

### DIFF
--- a/docs/man1/bmaptool.1
+++ b/docs/man1/bmaptool.1
@@ -195,6 +195,18 @@ tries to automatically discover the signature file.
 .RE
 
 .PP
+\-\-fingerprint FINGERPRINT
+.RS 2
+The GPG fingerprint which you expect to have signed the bmap file.
+.RE
+
+.PP
+\-\-keyring KEYRING
+.RS 2
+Path to the GPG keyring that will be used when verifying GPG signatures.
+.RE
+
+.PP
 \-\-nobmap
 .RS 2
 Disable automatic bmap file discovery and force flashing entire IMAGE without bmap.


### PR DESCRIPTION
Building on the work of #1 and #31 it is possible to further refactor the gpg verification code and add additional verification mechanisms other than using the python gpgme binding. With these changes, it is possible to pass a gpg keyring to bmaptool. So now I can instruct consumers of my disk images to run this:

    bmaptool copy --keyring=/usr/share/keyrings/debian-keyring.gpg http://disk.img /dev/sda

And they will have the assurance that whatever they download, extract and copy to their disk was signed by the same gpg keys as their Debian OS. For even more paranoid people there is the --fingerprint option which forces the bmap file to be signed by the given fingerprint.

What do you think?