### PR TITLE
document how to run tests without venv nor hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,10 @@ Finally, to run tests use `unittest`:
 python3 -m unittest -bv
 ```
 
+On platforms without hatch or venv you can also directly execute the tests:
+
+    PATH=tests/bin:$PATH PYTHONPATH=src python3 -m unittest -bv
+
 ## Project and maintainer
 
 The bmaptool project implements bmap-related tools and API modules. The entire

--- a/tests/bin/bmaptool
+++ b/tests/bin/bmaptool
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/env python3 -m src.bmaptool "$@"


### PR DESCRIPTION
It is possible to run bmaptool and the testsuite without venv, without hatch, without pip and without building and installing anything into venv by just running this:

    PATH=tests/bin:$PATH PYTHONPATH=src python3 -m unittest -bv

This assumes that a tool called `bmaptool` is in `$PATH` and essentially runs `python3 -m src.bmaptool`.

I find this way of running the tests quite a bit easier than going through all the venv, building and installation steps.