### PR TITLE
Add support for FTP authentication

### DIFF
--- a/src/bmaptool/TransRead.py
+++ b/src/bmaptool/TransRead.py
@@ -607,7 +607,7 @@ class TransRead(object):
             except netrc.NetrcParseError as e:
                 _log.error(f"Error parsing line {e.lineno} of {e.filename}: {e.msg}")
 
-        if username and password:
+        if username and password and parsed_url.scheme in ("http", "https"):
             # Unfortunately, in order to handle URLs which contain username
             # and password (e.g., http://user:password@my.site.org), we need to
             # do few extra things.


### PR DESCRIPTION
The documentation states that "if the server requires authentication, user name and password may be specified in the URL". I expected this authentication mechanism to work with FTP, but it does not.

Looking at the code, I saw that all the logic was in place to easily support FTP authentication, so this PR adds support for FTP authentication.