### PR TITLE
Respect query part of the url when operating on the path

### DIFF
--- a/src/bmaptool/TransRead.py
+++ b/src/bmaptool/TransRead.py
@@ -583,6 +583,10 @@ class TransRead(object):
 
         parsed_url = urllib.parse.urlparse(url)
 
+        # figuring out the decompression program to use relies on the
+        # extension, so strip off any potential query parts
+        self.name = parsed_url.path
+
         if parsed_url.scheme == "ssh":
             # Unfortunately, urllib2 does not handle "ssh://" URLs
             self._open_url_ssh(parsed_url)


### PR DESCRIPTION
This allows one to use bmaptool, with artifacts from gitlab CI which have a `?job=...` query parameter at the end of the URL:
    
 - ignore the query part of the URL when determining the compression type
 - ignore the query part of the URL when computing the basename and stripping off the filename extension
 - first strip off and then re-apply the query part of the URL when adding the .bmap extension to the path
