### PR TITLE
Fixup gpg tests

### DIFF
--- a/src/bmaptool/CLI.py
+++ b/src/bmaptool/CLI.py
@@ -238,7 +238,7 @@ def verify_bmap_signature_gpgbin(bmap_obj, detached_sig, gpgargv):
 
 def verify_bmap_signature_gpgv(bmap_obj, detached_sig):
     return verify_bmap_signature_gpgbin(
-        bmap_obj, detached_sig, ["gpgv", "--status-fd=2"]
+        bmap_obj, detached_sig, ["gpgv", "--output=-", "--status-fd=2"]
     )
 
 

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -22,6 +22,20 @@ import sys
 import tempfile
 import tests.helpers
 import shutil
+from dataclasses import dataclass
+
+
+@dataclass
+class Key:
+    gnupghome: str
+    uid: str
+    fpr: str = None
+
+
+testkeys = {
+    "correct": Key("tests/test-data/gnupg", "correct <foo@bar.org>"),
+    "unknown": Key("tests/test-data/gnupg2", "unknown <blub@bla.net>"),
+}
 
 
 class TestCLI(unittest.TestCase):
@@ -33,7 +47,7 @@ class TestCLI(unittest.TestCase):
                 "--bmap",
                 "tests/test-data/test.image.bmap.v2.0",
                 "--bmap-sig",
-                "tests/test-data/signatures/test.image.bmap.v2.0correct.asc",
+                "tests/test-data/signatures/test.image.bmap.v2.0correct.det.asc",
                 "tests/test-data/test.image.gz",
                 self.tmpfile,
             ],
@@ -55,7 +69,7 @@ class TestCLI(unittest.TestCase):
                 "--bmap",
                 "tests/test-data/test.image.bmap.v2.0",
                 "--bmap-sig",
-                "tests/test-data/signatures/test.image.bmap.v2.0imposter.asc",
+                "tests/test-data/signatures/test.image.bmap.v2.0unknown.det.asc",
                 "tests/test-data/test.image.gz",
                 self.tmpfile,
             ],
@@ -75,7 +89,7 @@ class TestCLI(unittest.TestCase):
                 "--bmap",
                 "tests/test-data/test.image.bmap.v1.4",
                 "--bmap-sig",
-                "tests/test-data/signatures/test.image.bmap.v2.0correct.asc",
+                "tests/test-data/signatures/test.image.bmap.v2.0correct.det.asc",
                 "tests/test-data/test.image.gz",
                 self.tmpfile,
             ],
@@ -87,7 +101,7 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(completed_process.stdout, b"")
         self.assertIn(b"discovered a BAD GPG signature", completed_process.stderr)
 
-    def test_wrong_signature_uknown_signer(self):
+    def test_wrong_signature_unknown_signer(self):
         completed_process = subprocess.run(
             [
                 "bmaptool",
@@ -95,7 +109,7 @@ class TestCLI(unittest.TestCase):
                 "--bmap",
                 "tests/test-data/test.image.bmap.v1.4",
                 "--bmap-sig",
-                "tests/test-data/signatures/test.image.bmap.v2.0imposter.asc",
+                "tests/test-data/signatures/test.image.bmap.v2.0unknown.det.asc",
                 "tests/test-data/test.image.gz",
                 self.tmpfile,
             ],
@@ -113,7 +127,7 @@ class TestCLI(unittest.TestCase):
                 "bmaptool",
                 "copy",
                 "--bmap",
-                "tests/test-data/signatures/test.image.bmap.v2.0correct.det.asc",
+                "tests/test-data/signatures/test.image.bmap.v2.0correct.asc",
                 "tests/test-data/test.image.gz",
                 self.tmpfile,
             ],
@@ -134,56 +148,58 @@ class TestCLI(unittest.TestCase):
             self.skipTest("python module 'gpg' missing")
 
         os.makedirs("tests/test-data/signatures", exist_ok=True)
-        for gnupghome, userid in [
-            ("tests/test-data/gnupg/", "correct <foo@bar.org>"),
-            ("tests/test-data/gnupg2/", "imposter <blub@bla.net>"),
-        ]:
-            if os.path.exists(gnupghome):
-                shutil.rmtree(gnupghome)
-            os.makedirs(gnupghome)
-            context = gpg.Context(home_dir=gnupghome, armor=True)
+        for key in testkeys.values():
+            if os.path.exists(key.gnupghome):
+                shutil.rmtree(key.gnupghome)
+            os.makedirs(key.gnupghome)
+            context = gpg.Context(home_dir=key.gnupghome)
             dmkey = context.create_key(
-                userid,
+                key.uid,
                 algorithm="rsa3072",
                 expires_in=31536000,
                 sign=True,
                 certify=True,
             )
+            key.fpr = dmkey.fpr
+            with open(f"{key.gnupghome}.keyring", "wb") as f:
+                f.write(context.key_export_minimal())
             for bmapv in ["2.0", "1.4"]:
                 testp = "tests/test-data"
                 imbn = "test.image.bmap.v"
-                with open(f"{testp}/{imbn}{bmapv}", "rb") as bmapf, open(
-                    f"{testp}/signatures/{imbn}{bmapv}{userid.split()[0]}.asc",
-                    "wb",
-                ) as sigf, open(
-                    f"{testp}/signatures/{imbn}{bmapv}{userid.split()[0]}.det.asc",
-                    "wb",
-                ) as detsigf:
+                with open(f"{testp}/{imbn}{bmapv}", "rb") as bmapf:
                     bmapcontent = bmapf.read()
-                    signed_data, result = context.sign(
-                        bmapcontent, mode=gpg.constants.sig.mode.DETACH
-                    )
-                    sigf.write(signed_data)
-                    signed_data, result = context.sign(
-                        bmapcontent, mode=gpg.constants.sig.mode.CLEAR
-                    )
-                    detsigf.write(signed_data)
-        os.environ["GNUPGHOME"] = "tests/test-data/gnupg/"
+                    with open(
+                        f"{testp}/signatures/{imbn}{bmapv}{key.uid.split()[0]}.asc",
+                        "wb",
+                    ) as sigf:
+                        signed_data, result = context.sign(
+                            bmapcontent, mode=gpg.constants.sig.mode.CLEAR
+                        )
+                        sigf.write(signed_data)
+                        plaintext, sigs = context.verify(signed_data, None)
+                    with open(
+                        f"{testp}/signatures/{imbn}{bmapv}{key.uid.split()[0]}.det.asc",
+                        "wb",
+                    ) as detsigf:
+                        signed_data, result = context.sign(
+                            bmapcontent, mode=gpg.constants.sig.mode.DETACH
+                        )
+                        detsigf.write(signed_data)
+
         self.tmpfile = tempfile.mkstemp(prefix="testfile_", dir=".")[1]
+        os.environ["GNUPGHOME"] = testkeys["correct"].gnupghome
 
     def tearDown(self):
         os.unlink(self.tmpfile)
-        for gnupghome, userid in [
-            ("tests/test-data/gnupg/", "correct <foo@bar.org>"),
-            ("tests/test-data/gnupg2/", "imposter <blub@bla.net>"),
-        ]:
-            shutil.rmtree(gnupghome)
+        for key in testkeys.values():
+            shutil.rmtree(key.gnupghome)
+            os.unlink(f"{key.gnupghome}.keyring")
             for bmapv in ["2.0", "1.4"]:
                 testp = "tests/test-data"
                 imbn = "test.image.bmap.v"
-                os.unlink(f"{testp}/signatures/{imbn}{bmapv}{userid.split()[0]}.asc")
+                os.unlink(f"{testp}/signatures/{imbn}{bmapv}{key.uid.split()[0]}.asc")
                 os.unlink(
-                    f"{testp}/signatures/{imbn}{bmapv}{userid.split()[0]}.det.asc"
+                    f"{testp}/signatures/{imbn}{bmapv}{key.uid.split()[0]}.det.asc"
                 )
         os.rmdir("tests/test-data/signatures")
 

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -33,8 +33,8 @@ class Key:
 
 
 testkeys = {
-    "correct": Key("tests/test-data/gnupg", "correct <foo@bar.org>"),
-    "unknown": Key("tests/test-data/gnupg2", "unknown <blub@bla.net>"),
+    "correct": Key(None, "correct <foo@bar.org>", None),
+    "unknown": Key(None, "unknown <blub@bla.net>", None),
 }
 
 
@@ -149,9 +149,8 @@ class TestCLI(unittest.TestCase):
 
         os.makedirs("tests/test-data/signatures", exist_ok=True)
         for key in testkeys.values():
-            if os.path.exists(key.gnupghome):
-                shutil.rmtree(key.gnupghome)
-            os.makedirs(key.gnupghome)
+            assert key.gnupghome is None
+            key.gnupghome = tempfile.mkdtemp(prefix="bmaptool")
             context = gpg.Context(home_dir=key.gnupghome)
             dmkey = context.create_key(
                 key.uid,
@@ -194,6 +193,7 @@ class TestCLI(unittest.TestCase):
         for key in testkeys.values():
             shutil.rmtree(key.gnupghome)
             os.unlink(f"{key.gnupghome}.keyring")
+            key.gnupghome = None
             for bmapv in ["2.0", "1.4"]:
                 testp = "tests/test-data"
                 imbn = "test.image.bmap.v"


### PR DESCRIPTION
   - detached and clear-signed data was swapped
   - instead of duplicating gnupghome and uids, use a global dictionary
   - export the keyring for each key in preparation for --keyring
   - store the fingerprint in the fpr attribute of a global dictionary
   - key name "imposter" is a misnomer, better is "unknown"
   - fix function name uknown -> unknown
   - export the "correct" GNUPGHOME as an environment variable
   - gpgv must be run with --output=- to write the signed text from a       clearsigned file
   - Create a new temporary directory for GNUPGHOME