### PR TITLE
tests/test_bmap_helpers.py: avoid build failure from disorderfs

### DIFF
--- a/tests/test_bmap_helpers.py
+++ b/tests/test_bmap_helpers.py
@@ -64,13 +64,13 @@ class TestBmapHelpers(unittest.TestCase):
         """Check a file system type is returned when used with a symlink"""
 
         with TemporaryDirectory(prefix="testdir_", dir=".") as directory:
-            fobj = tempfile.NamedTemporaryFile(
+            with tempfile.NamedTemporaryFile(
                 "r", prefix="testfile_", delete=False, dir=directory, suffix=".img"
-            )
-            lnk = os.path.join(directory, "test_symlink")
-            os.symlink(fobj.name, lnk)
-            fstype = BmapHelpers.get_file_system_type(lnk)
-            self.assertTrue(fstype)
+            ) as fobj:
+                lnk = os.path.join(directory, "test_symlink")
+                os.symlink(fobj.name, lnk)
+                fstype = BmapHelpers.get_file_system_type(lnk)
+                self.assertTrue(fstype)
 
     def test_is_zfs_configuration_compatible_enabled(self):
         """Check compatibility check is true when zfs param is set correctly"""


### PR DESCRIPTION
When running under `disorderfs --shuffle-dirents=yes`, the following Python code fails:

```py
with TemporaryDirectory(prefix="testdir_", dir=".") as directory:
    fobj = tempfile.NamedTemporaryFile(
        "r", delete=False, dir=directory
    )
```

```
Traceback (most recent call last):
  File "/tmp/disorder/test.py", line 4, in <module>
    with TemporaryDirectory(prefix="testdir_", dir=".") as directory:
  File "/usr/lib/python3.11/tempfile.py", line 1052, in __exit__
    self.cleanup()
  File "/usr/lib/python3.11/tempfile.py", line 1056, in cleanup
    self._rmtree(self.name, ignore_errors=self._ignore_cleanup_errors)
  File "/usr/lib/python3.11/tempfile.py", line 1038, in _rmtree
    _rmtree(name, onerror=onerror)
  File "/usr/lib/python3.11/shutil.py", line 738, in rmtree
    onerror(os.rmdir, path, sys.exc_info())
  File "/usr/lib/python3.11/shutil.py", line 736, in rmtree
    os.rmdir(path, dir_fd=dir_fd)
OSError: [Errno 39] Directory not empty: './testdir_6jhyg1o6'
```

This might be because the order of deletion is now such that the variable `fobj` no longer gets cleaned up before `rmtree()` is called by `TemporaryDirectory` and thus, the file behind `fobj` is no longer unlinked early enough.

The problem is fixed by closing `fobj` (and thus deleting it) before leaving the context manager.