### PR TITLE
remove the runtime dependecy on six

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Package: bmaptool
 Architecture: all
 Depends:
  python3,
- python3-six,
  ${misc:Depends},
  ${python3:Depends},
 Recommends:


### PR DESCRIPTION
Hi,

`six` has been cleansed from the current codebase, no need to pull it in anymore

https://salsa.debian.org/debian/bmap-tools/-/pipelines/845598

https://wiki.debian.org/Python3-six-removal