### PR TITLE
Resolve symlinks in device path for removable check

### DIFF
--- a/src/bmaptool/CLI.py
+++ b/src/bmaptool/CLI.py
@@ -541,7 +541,7 @@ def open_files(args):
             # /sys/block/<devicename>/removable attribute. The value in the
             # file is "1" if removable, and "0" if not removable.
             removable_path = os.path.join(
-                "/sys/block", os.path.basename(args.dest), "removable"
+                "/sys/block", os.path.basename(os.path.realpath(args.dest)), "removable"
             )
             try:
                 removable_value = open(removable_path, "r").read(1)


### PR DESCRIPTION
When running with `--removable-device`, the basename of `dest` is used to construct the path of the "removable" sysfs file for the device. However, if `dest` is a symlink the basename may be very different from the actual device name, and theoretically might even match a different device. Make the path absolute and resolve any symlinks before taking the basename to avoid that problem.

This is of practical importance because it allows using `/dev/disk/...` symlinks created by udev, which is much less error-prone than using e.g. `/dev/sdX`.